### PR TITLE
Update `primary_connect_proto` version to 0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.7.0
+
+- Updated dependency on `primary_connect_proto` 0.19.0
+
 ## 1.6.0
 
 - Updated dependency on `primary_connect_proto` 0.18.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,74 @@
+PATH
+  remote: .
+  specs:
+    primary_connect_client (1.7.0)
+      primary_connect_proto (~> 0.19.0, >= 0.19.0)
+      typhoeus (~> 1.0, >= 1.0.1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.2)
+    byebug (11.1.3)
+    coderay (1.1.3)
+    diff-lcs (1.5.0)
+    ethon (0.16.0)
+      ffi (>= 1.15.0)
+    ffi (1.15.5)
+    google-protobuf (3.22.0-arm64-darwin)
+    jaro_winkler (1.5.4)
+    method_source (1.0.0)
+    parallel (1.22.1)
+    parser (3.2.1.0)
+      ast (~> 2.4.1)
+    primary_connect_proto (0.19.0)
+      google-protobuf (~> 3.22.0)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.10.1)
+      byebug (~> 11.0)
+      pry (>= 0.13, < 0.15)
+    psych (5.1.0)
+      stringio
+    rainbow (3.1.1)
+    rake (13.0.6)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.1)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.0)
+    rubocop (0.66.0)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.5, != 2.5.1.1)
+      psych (>= 3.1.0)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 1.6)
+    ruby-progressbar (1.11.0)
+    stringio (3.0.5)
+    typhoeus (1.4.0)
+      ethon (>= 0.9.0)
+    unicode-display_width (1.5.0)
+
+PLATFORMS
+  arm64-darwin-20
+
+DEPENDENCIES
+  primary_connect_client!
+  pry-byebug
+  rake (~> 13.0.1)
+  rspec (~> 3.6, >= 3.6.0)
+  rubocop (~> 0.66.0)
+
+BUNDLED WITH
+   2.2.26

--- a/lib/primary_connect_client/version.rb
+++ b/lib/primary_connect_client/version.rb
@@ -11,5 +11,5 @@ OpenAPI Generator version: 5.3.0
 =end
 
 module PrimaryConnectClient
-  VERSION = '1.6.0'
+  VERSION = '1.7.0'
 end

--- a/primary_connect_client.gemspec
+++ b/primary_connect_client.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.4"
 
   s.add_runtime_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'
-  s.add_runtime_dependency 'primary_connect_proto', '~> 0.18.0', '>= 0.18.0'
+  s.add_runtime_dependency 'primary_connect_proto', '~> 0.19.0', '>= 0.19.0'
 
   s.add_development_dependency 'rspec', '~> 3.6', '>= 3.6.0'
 


### PR DESCRIPTION
Updates dependency on stable `google-protobuf` v 3.22